### PR TITLE
Fix broken edit this page link

### DIFF
--- a/Game/_config.yml
+++ b/Game/_config.yml
@@ -10,8 +10,9 @@ back_to_top_text: "Back to top"
 
 gh_edit_link: true # show or hide edit this page link
 gh_edit_link_text: "Edit this page on GitHub"
-gh_edit_repository: "https://github.com/CleverRaven/Cataclysm-DDA" # the github URL for your repo
-gh_edit_branch: "master/doc" # the branch that your docs is served from
+gh_edit_repository: "https://github.com/bombasticSlacks/DDADocs" # the github URL for your repo
+gh_edit_branch: "master" # the branch that your docs is served from
+gh_edit_source: "Game"
 # gh_edit_source: docs # the source that your files originate from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
 


### PR DESCRIPTION
Points into the current repo instead of the upstream DDA repo.

Also according to previous discussion we need to poke the repo every once in a while to keep the rebuild action going.